### PR TITLE
chore(chess) Change chess games size to 5

### DIFF
--- a/.github/workflows/update-chess-stats-action.yml
+++ b/.github/workflows/update-chess-stats-action.yml
@@ -22,3 +22,4 @@ jobs:
           COMMIT_EMAIL: ${{ vars.COMMIT_EMAIL }}
           COMMIT_MSG: 'chore(chess): [NO-REF] Update chess stats ⚡'
           COMMIT_USERNAME: ${{ vars.COMMIT_USERNAME }}
+          GAMES_SIZE: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation workflow to include a parameter that limits chess statistics to the five most recent games, ensuring more consistent and focused updates.
  * End users may notice stats now reflect a smaller, recent game sample rather than a broader history.
  * Commit author configuration remains unchanged, and the workflow’s schedule and overall behavior continue as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->